### PR TITLE
feat: 스터디룸 업데이트 Cron 생성

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "db:init:local": "docker-compose --env-file .local.env -f docker-compose.db.yml up -d",
     "db:save:local": "dotenv -e .local.env -- yarn prisma migrate dev",
-    "deploy:dev": "NODE_ENV=dev node dist/main.js"
+    "deploy:dev": "NODE_ENV=dev node dist/main.js",
+    "seed:studyroom:local": "dotenv -e .local.env -- npx ts-node ./prisma/seeds/insert-studyrooms.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/config": "^3.2.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^4.0.1",
     "@prisma/client": "^5.9.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "db:init:local": "docker-compose --env-file .local.env -f docker-compose.db.yml up -d",
     "db:save:local": "dotenv -e .local.env -- yarn prisma migrate dev",
+    "db:save:dev": "dotenv -e .dev.env -- yarn prisma migrate dev",
     "deploy:dev": "NODE_ENV=dev node dist/main.js",
-    "seed:studyroom:local": "dotenv -e .local.env -- npx ts-node ./prisma/seeds/insert-studyrooms.ts"
+    "seed:studyroom:local": "dotenv -e .local.env -- npx ts-node ./prisma/seeds/insert-studyrooms.ts",
+    "seed:studyroom:dev": "dotenv -e .dev.env -- npx ts-node ./prisma/seeds/insert-studyrooms.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/schedule": "^4.0.1",
     "@prisma/client": "^5.9.1",
+    "axios": "^1.6.7",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "joi": "^17.12.1",

--- a/prisma/migrations/20240208094119_set_starts_at_to_int_and_add_unique_constraint/migration.sql
+++ b/prisma/migrations/20240208094119_set_starts_at_to_int_and_add_unique_constraint/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `start_at` on the `studyroom_slot` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[studyroom_id,date,starts_at]` on the table `studyroom_slot` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `starts_at` to the `studyroom_slot` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "studyroom_slot" DROP COLUMN "start_at",
+ADD COLUMN     "starts_at" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "studyroom_slot_studyroom_id_date_starts_at_key" ON "studyroom_slot"("studyroom_id", "date", "starts_at");

--- a/prisma/migrations/20240208101640_remove_sejongpid_from_studyroom/migration.sql
+++ b/prisma/migrations/20240208101640_remove_sejongpid_from_studyroom/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `sejong_pid` on the `studyroom` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "studyroom" DROP COLUMN "sejong_pid";

--- a/prisma/migrations/20240208115725_add_is_closed_to_studyroom_slot/migration.sql
+++ b/prisma/migrations/20240208115725_add_is_closed_to_studyroom_slot/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `is_closed` to the `studyroom_slot` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "studyroom_slot" ADD COLUMN     "is_closed" BOOLEAN NOT NULL;

--- a/prisma/migrations/20240208120739_change_slot_id_type_to_string/migration.sql
+++ b/prisma/migrations/20240208120739_change_slot_id_type_to_string/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - The primary key for the `studyroom_slot` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "reservation_slot" DROP CONSTRAINT "reservation_slot_slot_id_fkey";
+
+-- AlterTable
+ALTER TABLE "reservation_slot" ALTER COLUMN "slot_id" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "studyroom_slot" DROP CONSTRAINT "studyroom_slot_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "studyroom_slot_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "studyroom_slot_id_seq";
+
+-- AddForeignKey
+ALTER TABLE "reservation_slot" ADD CONSTRAINT "reservation_slot_slot_id_fkey" FOREIGN KEY ("slot_id") REFERENCES "studyroom_slot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,7 +148,7 @@ model Studyroom {
 }
 
 model StudyroomSlot {
-  id              Int               @id @default(autoincrement())
+  id              String            @id
   studyroomId     Int               @map("studyroom_id")
   date            DateTime          @db.Date
   startsAt        Int               @map("starts_at")
@@ -179,7 +179,7 @@ model StudyroomReservation {
 
 model ReservationSlot {
   id              Int               @id @default(autoincrement())
-  slotId          Int               @map("slot_id")
+  slotId          String            @map("slot_id")
   reservationId   Int               @map("reservation_id")
 
   studyroomSlot         StudyroomSlot         @relation(fields: [slotId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,6 +153,7 @@ model StudyroomSlot {
   date            DateTime          @db.Date
   startsAt        Int               @map("starts_at")
   isReserved      Boolean           @map("is_reserved")
+  isClosed        Boolean           @map("is_closed")
   createdAt       DateTime          @default(now()) @map("created_at")
   updatedAt       DateTime          @updatedAt @map("updated_at")
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,7 +152,7 @@ model StudyroomSlot {
   id              Int               @id @default(autoincrement())
   studyroomId     Int               @map("studyroom_id")
   date            DateTime          @db.Date
-  startsAt        DateTime          @db.Time() @map("start_at")
+  startsAt        Int               @map("starts_at")
   isReserved      Boolean           @map("is_reserved")
   createdAt       DateTime          @default(now()) @map("created_at")
   updatedAt       DateTime          @updatedAt @map("updated_at")
@@ -161,6 +161,7 @@ model StudyroomSlot {
   reservations    ReservationSlot[]
 
   @@map("studyroom_slot")
+  @@unique([studyroomId, date, startsAt])
 }
 
 model StudyroomReservation {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,7 +132,6 @@ model UserAssignment {
 
 model Studyroom {
   id              Int               @id @default(autoincrement())
-  sejongPid       String            @map("sejong_pid")
   name            String
   location        String
   operatingHours  String            @map("operating_hours")

--- a/prisma/seeds/insert-studyrooms.ts
+++ b/prisma/seeds/insert-studyrooms.ts
@@ -14,6 +14,7 @@ async function main() {
   console.log(`Inserting ${rooms.length} studyrooms`);
   await prisma.studyroom.createMany({
     data: rooms,
+    skipDuplicates: true,
   });
   console.log('Seeding studyrooms complete');
 }

--- a/prisma/seeds/insert-studyrooms.ts
+++ b/prisma/seeds/insert-studyrooms.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient({
+  datasources: {
+    db: {
+      url: process.env.DATABASE_URL,
+    },
+  },
+});
+
+const rooms = require('./rooms.json');
+
+async function main() {
+  await prisma.studyroom.createMany({
+    data: rooms,
+  });
+}
+
+main();

--- a/prisma/seeds/insert-studyrooms.ts
+++ b/prisma/seeds/insert-studyrooms.ts
@@ -11,9 +11,11 @@ const prisma = new PrismaClient({
 const rooms = require('./rooms.json');
 
 async function main() {
+  console.log(`Inserting ${rooms.length} studyrooms`);
   await prisma.studyroom.createMany({
     data: rooms,
   });
+  console.log('Seeding studyrooms complete');
 }
 
 main();

--- a/prisma/seeds/rooms.json
+++ b/prisma/seeds/rooms.json
@@ -1,0 +1,200 @@
+[
+  {
+    "id": 11,
+    "name": "01 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 6,
+    "maxUsers": 12,
+    "isCinema": false
+  },
+  {
+    "id": 10,
+    "name": "02 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 12,
+    "name": "03 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 13,
+    "name": "04 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 14,
+    "name": "05 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 15,
+    "name": "06 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 1,
+    "name": "07 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 2,
+    "name": "08 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 3,
+    "name": "09 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 9,
+    "name": "10 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 4,
+    "name": "11 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 5,
+    "name": "12 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 16,
+    "name": "13 스터디룸(4층)",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 3,
+    "maxUsers": 6,
+    "isCinema": false
+  },
+  {
+    "id": 54,
+    "name": "시네마룸1",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 2,
+    "maxUsers": 3,
+    "isCinema": true
+  },
+  {
+    "id": 55,
+    "name": "시네마룸2",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 2,
+    "maxUsers": 3,
+    "isCinema": true
+  },
+  {
+    "id": 56,
+    "name": "시네마룸3",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 2,
+    "maxUsers": 3,
+    "isCinema": true
+  },
+  {
+    "id": 57,
+    "name": "시네마룸4",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 2,
+    "maxUsers": 3,
+    "isCinema": true
+  },
+  {
+    "id": 59,
+    "name": "시네마룸5",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 2,
+    "maxUsers": 3,
+    "isCinema": true
+  },
+  {
+    "id": 60,
+    "name": "시네마룸6",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 2,
+    "maxUsers": 3,
+    "isCinema": true
+  },
+  {
+    "id": 34,
+    "name": "진관홀 스터디룸1",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 5,
+    "maxUsers": 16,
+    "isCinema": false
+  },
+  {
+    "id": 35,
+    "name": "진관홀 스터디룸2",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 5,
+    "maxUsers": 16,
+    "isCinema": false
+  },
+  {
+    "id": 36,
+    "name": "진관홀 스터디룸3",
+    "location": "학술정보원 4층",
+    "operatingHours": "10:00~16:00",
+    "minUsers": 5,
+    "maxUsers": 16,
+    "isCinema": false
+  }
+]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,11 +1,12 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { CommonModule } from 'src/common/common.module';
 import { LoggerMiddleware } from 'src/common/middlewares/logger.middleware';
+import { StudyroomModule } from 'src/studyroom/studyroom.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
 @Module({
-  imports: [CommonModule],
+  imports: [CommonModule, StudyroomModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/studyroom/studyroom.controller.ts
+++ b/src/studyroom/studyroom.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('studyroom')
+export class StudyroomController {}

--- a/src/studyroom/studyroom.module.ts
+++ b/src/studyroom/studyroom.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { StudyroomController } from './studyroom.controller';
+import { StudyroomRepository } from './studyroom.repository';
+import { StudyroomService } from './studyroom.service';
+
+@Module({
+  imports: [ScheduleModule.forRoot()],
+  controllers: [StudyroomController],
+  providers: [StudyroomService, StudyroomRepository],
+})
+export class StudyroomModule {}

--- a/src/studyroom/studyroom.repository.ts
+++ b/src/studyroom/studyroom.repository.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class StudyroomRepository {}

--- a/src/studyroom/studyroom.service.ts
+++ b/src/studyroom/studyroom.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class StudyroomService {
+  constructor() {}
+}

--- a/src/studyroom/studyroom.service.ts
+++ b/src/studyroom/studyroom.service.ts
@@ -1,6 +1,52 @@
 import { Injectable } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import axios from 'axios';
+import { PrismaService } from 'src/common/services/prisma.service';
+import { RawStudyroom } from './types/rawStudyroom';
 
 @Injectable()
 export class StudyroomService {
-  constructor() {}
+  constructor(private readonly prismaService: PrismaService) {}
+
+  private getSlotTime(time: string) {
+    if (time.indexOf(':') === -1) {
+      return -1;
+    }
+    return parseInt(time.split(':')[0]);
+  }
+
+  @Cron('*/10 * * * * *')
+  async handleCron() {
+    const res = await axios.get('http://34.22.85.208:8000/calendar');
+    const studyRooms = res.data as RawStudyroom[];
+    studyRooms.forEach(async (rawStudyRoom) => {
+      await this.prismaService.$transaction([
+        this.prismaService.studyroomSlot.deleteMany({
+          where: {
+            studyroomId: parseInt(rawStudyRoom.room_id),
+          },
+        }),
+        this.prismaService.studyroomSlot.createMany({
+          data: rawStudyRoom.slots.map((slot) => {
+            return {
+              id: `${rawStudyRoom.room_id}_${slot.date}_${slot.time}`,
+              studyroomId: parseInt(rawStudyRoom.room_id),
+              date: new Date(slot.date),
+              startsAt: this.getSlotTime(slot.time),
+              isReserved: slot.is_reserved,
+              isClosed: slot.is_closed,
+            };
+          }),
+          skipDuplicates: true,
+        }),
+      ]);
+    });
+
+    // const studyRoomSlots = await this.prismaService.studyroomSlot.findMany({});
+    // console.log(studyRoomSlots);
+
+    // console.log('------------------------');
+    // const studyRooms = await this.prismaService.studyroom.findMany({});
+    // console.log(studyRooms);
+  }
 }

--- a/src/studyroom/types/rawStudyroom.d.ts
+++ b/src/studyroom/types/rawStudyroom.d.ts
@@ -1,0 +1,11 @@
+export type RawStudyroomSlot = {
+  date: Date;
+  time: string;
+  is_reserved: boolean;
+  is_closed: boolean;
+};
+
+export type RawStudyroom = {
+  room_id: string;
+  slots: RawStudyroomSlot[];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,6 +1544,15 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+axios@^1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+  dependencies:
+    follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -2583,6 +2592,11 @@ flatted@^3.2.9:
   version "3.2.9"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
+
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
 foreground-child@^3.1.0:
   version "3.1.1"
@@ -4131,6 +4145,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,6 +762,14 @@
     multer "1.4.4-lts.1"
     tslib "2.6.2"
 
+"@nestjs/schedule@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/schedule/-/schedule-4.0.1.tgz#beb69f974e7adc96fd799f555ba0121c10d2d61b"
+  integrity sha512-cz2FNjsuoma+aGsG0cMmG6Dqg/BezbBWet1UTHtAuu6d2mXNTVcmoEQM2DIVG5Lfwb2hfSE2yZt8Moww+7y+mA==
+  dependencies:
+    cron "3.1.6"
+    uuid "9.0.1"
+
 "@nestjs/schematics@^10.0.0", "@nestjs/schematics@^10.0.1":
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@nestjs/schematics/-/schematics-10.1.0.tgz#bf9be846bafad0f45f0ea5ed80aaaf971bb90873"
@@ -1054,6 +1062,11 @@
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
+"@types/luxon@~3.3.0":
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.8.tgz#84dbf2d020a9209a272058725e168f21d331a67e"
+  integrity sha512-jYvz8UMLDgy3a5SkGJne8H7VA7zPV2Lwohjx0V8V31+SqAjNmurWMkk9cQhfvlcnXWudBpK9xPM1n4rljOcHYQ==
 
 "@types/methods@^1.1.4":
   version "1.1.4"
@@ -2031,6 +2044,14 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cron@3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/cron/-/cron-3.1.6.tgz#e7e1798a468e017c8d31459ecd7c2d088f97346c"
+  integrity sha512-cvFiQCeVzsA+QPM6fhjBtlKGij7tLLISnTSvFxVdnFGLdz+ZdXN37kNe0i2gefmdD17XuZA6n2uPVwzl4FxW/w==
+  dependencies:
+    "@types/luxon" "~3.3.0"
+    luxon "~3.4.0"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -3628,6 +3649,11 @@ lru-cache@^6.0.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
   integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
+
+luxon@~3.4.0:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.4.tgz#cf20dc27dc532ba41a169c43fdcc0063601577af"
+  integrity sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==
 
 magic-string@0.30.5:
   version "0.30.5"


### PR DESCRIPTION
- nest/schedule에 있는 `@Cron`을 사용해서 10초에 한번 스터디룸 정보 파싱하는 Flask API를 콜합니다.
- DB변경점이 많습니다.
   1. StudyroomSlot에 startsAt을 Int형으로 변경합니다. 10시부터 시작인 슬롯이면 10, 오후4시면 16 이런식으로 저장합니다.
   2. StudyroomSlot의 id를 기존 Int형에서 String으로 변경한 뒤 Default값을 삭제했습니다. 10초에 한번씩 새 row가 계속해서 쌓이기 때문에 금세 Int형의 범위를 넘어갈 것이기 때문에 변경했습니다. id의 기본 형태는 `${rawStudyRoom.room_id}_${slot.date}_${slot.time}`입니다.
   3. Studyroom에는 pid값이 없어서 삭제했습니다
   4. StudyroomSlot에 is_closed 필드를 추가해서 휴관일인지 여부에 대한 정보도 추가했습니다.
- 기본 스터디룸들을 넣는 seed스크립트를 만들었습니다. `yarn seed:studyroom:{환경}` 명령어로 seed 스크립트를 실행할 수 있습니다.