### PR TITLE
hotfix: 고전독서 슬롯 DB에 중복돼서 들어가는 오류 수정

### DIFF
--- a/prisma/migrations/20240902115221_add_unique_constraint_start_at_on_godok_slot/migration.sql
+++ b/prisma/migrations/20240902115221_add_unique_constraint_start_at_on_godok_slot/migration.sql
@@ -1,0 +1,9 @@
+TRUNCATE TABLE "godok_slot" RESTART IDENTITY; -- 삭제해도 다음 크론잡에 생성하므로 상관X
+
+DROP INDEX "godok_slot_slot_id_key";
+
+-- AlterTable
+ALTER TABLE "godok_slot" ALTER COLUMN "slot_id" DROP NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "godok_slot_starts_at_key" ON "godok_slot"("starts_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -247,8 +247,8 @@ model Book {
 
 model GodokSlot {
   id             String    @id @default(uuid())
-  slotId         String    @unique @map("slot_id")
-  startsAt       DateTime  @map("starts_at")
+  slotId         String?   @map("slot_id")
+  startsAt       DateTime  @unique @map("starts_at")
   availableSeats Int       @map("available_seats")
   totalSeats     Int       @map("total_seats")
   createdAt      DateTime  @default(now()) @map("created_at")

--- a/src/godok/godok.service.ts
+++ b/src/godok/godok.service.ts
@@ -68,20 +68,27 @@ export class GodokService {
     const rawGodokSlots = JSON.parse(res.data) as RawGodokSlot;
 
     for (const slot of rawGodokSlots) {
-      await this.prismaService.godokSlot.upsert({
-        where: {
-          slotId: slot.data_id,
-        },
-        create: {
-          slotId: slot.data_id,
-          startsAt: new Date(slot.date_time),
-          availableSeats: slot.available_seats,
-          totalSeats: slot.total_seats,
-        },
-        update: {
-          availableSeats: slot.available_seats,
-        },
-      });
+      const startsAt = new Date(slot.date_time);
+      try {
+        await this.prismaService.godokSlot.upsert({
+          where: {
+            startsAt,
+          },
+          create: {
+            slotId: slot.data_id,
+            startsAt,
+            availableSeats: slot.available_seats,
+            totalSeats: slot.total_seats,
+          },
+          update: {
+            slotId: slot.data_id,
+            availableSeats: slot.available_seats,
+            totalSeats: slot.total_seats,
+          },
+        });
+      } catch (error) {
+        console.error(error);
+      }
     }
   }
 


### PR DESCRIPTION
- classic.sejong 에서 예약이 꽉 찼을 때는 slot_id를 반환하지 않아서 같은 슬롯인데, slot_id가 있는 row와 없는 row 두개가 중복해서 존재하는 이슈가 있었습니다.
- start_at을 unique constraint로 추가하고, 이를 기준으로 upsert하도록 크론잡을 수정했습니다.