### PR TITLE
feat: 공지사항 전체 조회 방식 일부 개선

### DIFF
--- a/src/notice/dto/notice-preview.dto.ts
+++ b/src/notice/dto/notice-preview.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Notice } from '@prisma/client';
+
+export class NoticePreviewDto {
+  @ApiProperty({
+    description: '공지사항 id',
+    example: 1,
+    type: Number,
+  })
+  id!: number;
+
+  @ApiProperty({
+    description: '공지사항 제목',
+    example: '공지사항 제목',
+    type: String,
+  })
+  title!: string;
+
+  @ApiProperty({
+    description: '공지사항 생성 일자',
+    type: Date,
+  })
+  createdAt!: Date;
+
+  static from(notice: Notice): NoticePreviewDto {
+    return {
+      id: notice.id,
+      title: notice.title,
+      createdAt: notice.createdAt,
+    };
+  }
+}

--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -6,14 +6,13 @@ import {
   Param,
   Post,
   Put,
-  Query,
   Version,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { NoticeDto } from './dto/notice.dto';
 import { NoticeService } from './notice.service';
 import { CreateUpdateNoticePayload } from './payload/create-update-notice.payload';
-import { PaginationPayload } from './payload/pagination.payload';
+import { NoticePreviewDto } from './dto/notice-preview.dto';
 
 @ApiTags('공지사항 API')
 @Controller('notice')
@@ -78,24 +77,14 @@ export class NoticeController {
   @Version('1')
   @ApiOperation({
     summary: '공지사항 조회 api',
-    description:
-      '{skip}개 이후의 데이터를 {take}개 요청합니다. \n 아무런 queryData도 보내지 않을 경우 전부 가져옵니다.',
+    description: '공지사항을 조회합니다.',
   })
   @ApiOkResponse({
-    description: '전체 공지사항 목록을 반환합니다 (쿼리 파라미터가 없는 경우).',
-    type: [NoticeDto],
+    description: '전체 공지사항의 id, title, createdAt 필드를 조회합니다다.',
+    type: [NoticePreviewDto],
   })
   @Get()
-  async getNotice(
-    @Query() queryData: PaginationPayload,
-  ): Promise<NoticeDto[] | Partial<NoticeDto>[]> {
-    console.log(queryData);
-    if (queryData.skip == undefined && queryData.take == undefined) {
-      return this.noticeService.getNotice();
-    }
-    return this.noticeService.getNoticeByPagination({
-      skip: queryData.skip,
-      take: queryData.take,
-    });
+  async getNotice(): Promise<NoticePreviewDto[]> {
+    return this.noticeService.getNotice();
   }
 }

--- a/src/notice/notice.repository.ts
+++ b/src/notice/notice.repository.ts
@@ -2,13 +2,19 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/common/services/prisma.service';
 import { CreateUpdateNoticePayload } from './payload/create-update-notice.payload';
 import { Notice } from './types/notice.type';
+import { NoticePreviewDto } from './dto/notice-preview.dto';
 
 @Injectable()
 export class NoticeRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getNotice(): Promise<Notice[]> {
+  async getNotice(): Promise<NoticePreviewDto[]> {
     return this.prisma.notice.findMany({
+      select: {
+        id: true,
+        title: true,
+        createdAt: true,
+      },
       where: {
         deletedAt: null,
       },

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -2,7 +2,6 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { NoticeDto } from './dto/notice.dto';
 import { NoticeRepository } from './notice.repository';
 import { CreateUpdateNoticePayload } from './payload/create-update-notice.payload';
-import { PaginationPayload } from './payload/pagination.payload';
 
 @Injectable()
 export class NoticeService {
@@ -61,14 +60,14 @@ export class NoticeService {
     return this.noticeRepository.createPopupNotice(id);
   }
 
-  async getNoticeByPagination(
-    queryData: PaginationPayload,
-  ): Promise<Partial<NoticeDto>[]> {
-    const notice = await this.noticeRepository.getNoticeByPagination(
-      queryData.skip,
-      queryData.take,
-    );
+  // async getNoticeByPagination(
+  //   queryData: PaginationPayload,
+  // ): Promise<Partial<NoticeDto>[]> {
+  //   const notice = await this.noticeRepository.getNoticeByPagination(
+  //     queryData.skip,
+  //     queryData.take,
+  //   );
 
-    return notice;
-  }
+  //   return notice;
+  // }
 }


### PR DESCRIPTION
NoticePreviewDto를 기반으로 공지사항 전체 조회시 title과 createdAt, id를 포함하게 변경하였습니다. 특정 공지사항의 상세 조회 페이지에서 모든 필드가 필요할 경우 상세 조회 api에 해당 id를 사용해 가져오면 됩니다.