### PR TITLE
Feat/auth admin

### DIFF
--- a/src/app/app.controller.ts
+++ b/src/app/app.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiHeader, ApiOperation } from '@nestjs/swagger';
 import { CurrentUser } from 'src/auth/decorator/user.decorator';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 import { UserInfo } from 'src/auth/types/user-info.type';
 import { AppService } from './app.service';
+import { AdminApiGuard } from 'src/auth/guard/admin.guard';
 
 @Controller()
 export class AppController {
@@ -21,5 +22,17 @@ export class AppController {
   @ApiBearerAuth()
   async getHelloPrivate(@CurrentUser() user: UserInfo): Promise<UserInfo> {
     return user;
+  }
+
+  @Get('admin')
+  @UseGuards(AdminApiGuard)
+  @ApiOperation({ summary: 'Admin Api Health Check' })
+  @ApiHeader({
+    name: 'admin-api-key',
+    description: 'API key for admin access',
+    required: true,
+  })
+  getHelloAdmin(): string {
+    return this.appService.getHello();
   }
 }

--- a/src/app/modules/config.module.ts
+++ b/src/app/modules/config.module.ts
@@ -30,5 +30,6 @@ export const configModule = ConfigModule.forRoot({
     CANCEL_GODOK_RESERVATION_URL: Joi.string().required(),
     GET_USER_GODOK_STATUS_URL: Joi.string().required(),
     GET_COURSE_ATTENDANCE_URL: Joi.string().required(),
+    ADMIN_API_KEY: Joi.string().required(),
   }),
 });

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { AuthRepository } from './auth.repository';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './guard/jwt.strategy';
 import { TokenService } from './token.service';
+import { AdminApiStrategy } from './guard/admin.strategy';
 
 @Module({
   imports: [
@@ -21,13 +22,14 @@ import { TokenService } from './token.service';
       }),
     }),
   ],
-  exports: [],
+  exports: [AdminApiStrategy],
   controllers: [AuthController],
   providers: [
     AuthService,
     TokenService,
     ConfigService,
     JwtStrategy,
+    AdminApiStrategy,
     AuthRepository,
     EcampusService,
     AttendanceRepository,

--- a/src/auth/guard/admin.guard.ts
+++ b/src/auth/guard/admin.guard.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   CanActivate,
   ExecutionContext,
   ForbiddenException,
@@ -6,16 +7,28 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { AdminApiStrategy } from './admin.strategy';
+import { PasswordService } from 'src/common/services/password.service';
 
 @Injectable()
 export class AdminApiGuard implements CanActivate {
-  constructor(private readonly adminApiStrategy: AdminApiStrategy) {}
+  constructor(
+    private readonly adminApiStrategy: AdminApiStrategy,
+    private readonly passwordService: PasswordService,
+  ) {}
   canActivate(
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
     const request = context.switchToHttp().getRequest();
 
-    const apiKey = request.headers['admin-api-key'];
+    const pattern =
+      /^[0-9a-fA-F]{32}:(?:[0-9a-fA-F]{32}|[0-9a-fA-F]{64}|[0-9a-fA-F]{96})$/;
+    if (!pattern.test(request.headers['admin-api-key'])) {
+      throw new BadRequestException('올바른 api key 형식이 아닙니다.');
+    }
+
+    const apiKey = this.passwordService.decryptPassword(
+      request.headers['admin-api-key'],
+    );
     const result = this.adminApiStrategy.validateApiKey(apiKey);
     if (!result) {
       throw new ForbiddenException('권한이 없습니다.');

--- a/src/auth/guard/admin.guard.ts
+++ b/src/auth/guard/admin.guard.ts
@@ -1,0 +1,26 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { AdminApiStrategy } from './admin.strategy';
+
+@Injectable()
+export class AdminApiGuard implements CanActivate {
+  constructor(private readonly adminApiStrategy: AdminApiStrategy) {}
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    const apiKey = request.headers['admin-api-key'];
+    const result = this.adminApiStrategy.validateApiKey(apiKey);
+    if (!result) {
+      throw new ForbiddenException('권한이 없습니다.');
+    }
+
+    return true;
+  }
+}

--- a/src/auth/guard/admin.strategy.ts
+++ b/src/auth/guard/admin.strategy.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class AdminApiStrategy {
+  constructor(private readonly configservice: ConfigService) {}
+
+  validateApiKey(apiKey?: string): boolean {
+    const validApiKey = this.configservice.get<string>('ADMIN_API_KEY');
+    if (!apiKey || apiKey !== validApiKey) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -7,13 +7,20 @@ import {
   ParseIntPipe,
   Post,
   Put,
+  UseGuards,
   Version,
 } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiHeader,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { NoticeDto } from './dto/notice.dto';
 import { NoticeService } from './notice.service';
 import { CreateUpdateNoticePayload } from './payload/create-update-notice.payload';
 import { NoticePreviewDto } from './dto/notice-preview.dto';
+import { AdminApiGuard } from 'src/auth/guard/admin.guard';
 
 @ApiTags('공지사항 API')
 @Controller('notice')
@@ -35,6 +42,12 @@ export class NoticeController {
     summary: '팝업 공지사항 등록 API',
     description: '팝업 공지사항을 등록합니다.',
   })
+  @UseGuards(AdminApiGuard)
+  @ApiHeader({
+    name: 'admin-api-key',
+    description: 'API key for admin access',
+    required: true,
+  })
   @Post('popup/:id')
   async createPopupNotice(@Param('id') id: number): Promise<void> {
     return this.noticeService.createPopupNotice(id);
@@ -44,6 +57,12 @@ export class NoticeController {
   @ApiOperation({
     summary: '공지사항 생성 API',
     description: '공지사항을 생성합니다.',
+  })
+  @UseGuards(AdminApiGuard)
+  @ApiHeader({
+    name: 'admin-api-key',
+    description: 'API key for admin access',
+    required: true,
   })
   @Post('')
   async createNotice(
@@ -57,6 +76,12 @@ export class NoticeController {
     summary: '공지사항 수정 API',
     description: '공지사항을 수정합니다.',
   })
+  @UseGuards(AdminApiGuard)
+  @ApiHeader({
+    name: 'admin-api-key',
+    description: 'API key for admin access',
+    required: true,
+  })
   @Put(':id')
   async updateNotice(
     @Param('id') id: number,
@@ -69,6 +94,12 @@ export class NoticeController {
   @ApiOperation({
     summary: '공지사항 삭제 API',
     description: '공지사항을 삭제합니다.',
+  })
+  @UseGuards(AdminApiGuard)
+  @ApiHeader({
+    name: 'admin-api-key',
+    description: 'API key for admin access',
+    required: true,
   })
   @Delete(':id')
   async deleteNotice(@Param('id') id: number): Promise<void> {

--- a/src/notice/notice.module.ts
+++ b/src/notice/notice.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { NoticeController } from './notice.controller';
 import { NoticeRepository } from './notice.repository';
 import { NoticeService } from './notice.service';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [NoticeController],
   providers: [NoticeService, NoticeRepository],
 })


### PR DESCRIPTION
admin 전용 api의 인가 로직을 작성 후 적용했습니다.
인가 로직은 다음과 같습니다:
기본적으로 prefix password를 사용하는 프론트엔드를 존중하여 인가가 필요한 api에 접근할 경우 header에 인증키를 포함하여야 합니다.
이 인증키는 환경변수의 ADMIN_API_KEY값과 비교됩니다. 이 값은 가능하면 프론트엔드의 prefix password와 같은 값을 사용하도록 설정해주세요.

인가 로직이 적용된 api:
팝업 공지사항 등록 API
공지사항 생성 API
공지사항 수정 API
공지사항 삭제 API

다음 api가 추가되었습니다:
Admin Api Health Check